### PR TITLE
Create draft codemeta.json file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,141 @@
+{
+    "@context": "https://w3id.org/codemeta/3.0",
+    "applicationCategory": "SoftwareSourceCode,SoftwareApplication",
+    "author": [
+        {
+            "@type": "Person",
+            "@id": "https://github.com/alexandroskoliousis",
+            "familyName": "Koliousis",
+            "givenName": "Alexandros",
+            "email": "ak@akoliousis.com"
+        },
+        {
+            "@type": "Person",
+            "@id": "https://github.com/amil-m",
+            "familyName": "Mohanan",
+            "givenName": "Amil",
+            "email": "amil@mohanan.net"
+        },
+        {
+            "@id": "https://orcid.org/0000-0003-2478-6151",
+            "@type": "Person",
+            "affiliation": {
+                "name": "Northeastern University, London",
+                "@type": "Organization"
+            },
+            "familyName": "Ball",
+            "givenName": "Brian",
+            "email": "brian.ball@nulondon.ac.uk"
+        },
+        {
+            "@type": "Person",
+            "@id": "https://github.com/Prudhvivuda",
+            "familyName": "Vuda",
+            "givenName": "Prudhvi"
+        },
+        {
+            "@type": "Person",
+            "@id": "https://github.com/sudopluto",
+            "familyName": "Sharma",
+            "givenName": "Pranav"
+        },
+        {
+            "@type": "Person",
+            "@id": "https://github.com/PujithaSaiTulasi",
+            "familyName": "Muddhu",
+            "givenName": "Pujitha Sai Tulasi"
+        }
+    ],
+    "codeRepository": "https://github.com/alexandroskoliousis/polygraphs",
+    "dateCreated": "2021-04-16",
+    "description": "Philosophical simulations (epistemology)",
+    "identifier": "polygraphs",
+    "keywords": [
+        "philosophy",
+        "epistemology",
+        "simulation"
+    ],
+    "license": "https://spdx.org/licenses/MIT",
+    "name": "polygraphs",
+    "programmingLanguage": [
+        "Python",
+        "Jupyter Notebook"
+    ],
+    "referencePublication": [
+        {
+            "author": [
+                {
+                    "affiliation": {
+                        "name": "Northeastern University, London",
+                        "@type": "Organization"
+                    },
+                    "email": "brian.ball@nulondon.ac.uk",
+                    "familyName": "Ball",
+                    "givenName": "Brian",
+                    "@id": "https://orcid.org/0000-0003-2478-6151",
+                    "@type": "Person"
+                },
+                {
+                    "affiliation": {
+                        "name": "Northeastern University, London",
+                        "@type": "Organization"
+                    },
+                    "familyName": "Koliousis",
+                    "givenName": "Alexandros",
+                    "@type": "Person"
+                },
+                {
+                    "affiliation": {
+                        "name": "University of Bristol",
+                        "@type": "Organization"
+                    },
+                    "familyName": "Peacey",
+                    "givenName": "Mike",
+                    "@type": "Person"
+                }
+            ],
+            "datePublished": "2024-01-31",
+            "identifier": "https://doi.org/10.1057/s41599-024-02619-z",
+            "name": "Computational philosophy: reflections on the PolyGraphs project",
+            "url": "https://www.nature.com/articles/s41599-024-02619-z",
+            "@type": "ScholarlyArticle"
+        }
+    ],
+    "softwareRequirements": [
+        {
+            "name": "python",
+            "version": "3.11"
+        },
+        "jupyterlab",
+        {
+            "name": "tqdm",
+            "version": "4.64.1"
+        },
+        "ipywidgets",
+        {
+            "name": "pytorch",
+            "version": "2.2.0"
+        },
+        "seaborn",
+        "pyyaml",
+        {
+            "name": "dgl",
+            "version": "2.1.0"
+        },
+        "numpy",
+        "networkx",
+        "six",
+        "torch",
+        {
+            "name": "setuptools",
+            "version": ">=61.0"
+        },
+        "notebook"
+    ],
+    "codemeta:contIntegration": {
+        "@id": "https://raw.githubusercontent.com/alexandroskoliousis/polygraphs/main/.github/workflows/deploy.yml"
+    },
+    "continuousIntegration": "https://raw.githubusercontent.com/alexandroskoliousis/polygraphs/main/.github/workflows/deploy.yml",
+    "issueTracker": "https://github.com/alexandroskoliousis/polygraphs/issues",
+    "@type": "SoftwareSourceCode"
+}


### PR DESCRIPTION
Further to the email sent to Professor Brian Ball last week on behalf of the [CCP-AHC](https://www.ccpahc.ac.uk/) project, I'm opening this pull request to contribute a `codemeta.json` file.
Codemeta is a schema designed to enable software citation by standardising metadata about the project. It is defined and documented at https://codemeta.github.io/.
This pull request creates a file to that standard for this repository, starting from the details automatically filled out by https://autocodemeta.linkeddata.es/ and editing to fill in the gaps the generator is unable to automatically scrape with details manually extracted from the repository and linked pages.

Please do tell me in the discussion where details are inaccurate so that we can bring the codemeta.json file up to date with the project.